### PR TITLE
[4.x] update translation-pull-request workflows

### DIFF
--- a/.github/workflows/create-translation-pull-request-v4.yml
+++ b/.github/workflows/create-translation-pull-request-v4.yml
@@ -1,4 +1,4 @@
-name: Create translation pull request
+name: Create translation pull request J4
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    # Run daily at 7:26
+    # Run daily at 7:27
     - cron:  '27 7 * * *'
 
 permissions:
@@ -19,12 +19,13 @@ jobs:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
     # Only run this action the translation-bot repository in the translation branch
-    if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation' }}
+    if: (github.event_name == 'schedule' && github.repository == 'joomla-translation-bot/joomla-cms') || (github.event_name != 'schedule')
 
     steps:
       - uses: actions/checkout@v3
         # We need the full depth to create / update the pull request against the main repo
         with:
+          ref: translation
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
@@ -73,5 +74,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
         run: |
-          gh pr list -R joomla/joomla-cms --state open --author joomla-translation-bot -S "[4.x] Translation Update" | grep -v "No pull" || \
+          gh pr list -R joomla/joomla-cms --state open --author joomla-translation-bot -S "[4.x] Translation Update" --base 4.4-dev | grep -v "No pull" || \
             gh pr create --title "[4.x] Translation Update" --body "Automatically created pull request based on core-translation repository changes" -R joomla/joomla-cms --base 4.4-dev


### PR DESCRIPTION
Changes:
- update `create-translation-pull-request-v4.yml`
  - scheduled workflow [work only on default branch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)
  >Scheduled workflows run on the latest commit on the default or base branch. 

@HLeithner @wilsonge